### PR TITLE
msFullscreenchange should be msFullscreenChange

### DIFF
--- a/src/screenfull.js
+++ b/src/screenfull.js
@@ -49,7 +49,7 @@
 					'msFullscreenElement',
 					'msFullscreenEnabled',
 					'MSFullscreenChange',
-					'MSFullscreenerror'
+					'MSFullscreenError'
 				]
 			];
 			var i = 0;


### PR DESCRIPTION
...otherwise, it does not work in IE11 (see http://msdn.microsoft.com/en-us/library/ie/dn312066(v=vs.85).aspx)
