### PR TITLE
Add event listeners

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,7 +129,7 @@ $('img').on('click', event => {
 
 ```js
 if (screenfull.enabled) {
-	document.addEventListener(screenfull.raw.fullscreenchange, () => {
+	screenfull.onchange(() => {
 		console.log('Am I fullscreen? ' + (screenfull.isFullscreen ? 'Yes' : 'No'));
 	});
 }
@@ -139,7 +139,7 @@ if (screenfull.enabled) {
 
 ```js
 if (screenfull.enabled) {
-	document.addEventListener(screenfull.raw.fullscreenerror, event => {
+	screenfull.onerror(event => {
 		console.error('Failed to enable fullscreen', event);
 	});
 }
@@ -200,6 +200,11 @@ Brings you out of fullscreen.
 
 Requests fullscreen if not active, otherwise exits.
 
+#### .onchange()
+Add a listener for fullscreenchange event
+
+#### .onerror()
+Add a listener for fullscreenerror event
 
 ### Properties
 

--- a/src/screenfull.js
+++ b/src/screenfull.js
@@ -99,7 +99,10 @@
 		},
 		onchange: function(callback) {
 			document.addEventListener(fn.fullscreenchange, callback, false);
-		}
+		},
+		onerror: function(callback) {
+		  document.addEventListener(fn.fullscreenerror, callback, false);
+		},
 		raw: fn
 	};
 

--- a/src/screenfull.js
+++ b/src/screenfull.js
@@ -97,6 +97,9 @@
 				this.request(elem);
 			}
 		},
+		onchange: function(callback) {
+			document.addEventListener(fn.fullscreenchange, callback, false);
+		}
 		raw: fn
 	};
 

--- a/src/screenfull.js
+++ b/src/screenfull.js
@@ -97,11 +97,11 @@
 				this.request(elem);
 			}
 		},
-		onchange: function(callback) {
+		onchange: function (callback) {
 			document.addEventListener(fn.fullscreenchange, callback, false);
 		},
-		onerror: function(callback) {
-		  document.addEventListener(fn.fullscreenerror, callback, false);
+		onerror: function (callback) {
+			document.addEventListener(fn.fullscreenerror, callback, false);
 		},
 		raw: fn
 	};


### PR DESCRIPTION
shall we add an method to listen the fullscreenchange event? 
When some element enter full screen, I wanna edit its attribute, and when it exit full screen, i wanna edit its attribute again.  
I found it inconvenient without "onchange' method. 