### PR TITLE
Allow screenfull to work in non-browser JS environments

### DIFF
--- a/src/screenfull.js
+++ b/src/screenfull.js
@@ -1,6 +1,7 @@
 (function () {
 	'use strict';
 
+	var document = typeof window !== 'undefined' ? window.document : {};
 	var isCommonjs = typeof module !== 'undefined' && module.exports;
 	var keyboardAllowed = typeof Element !== 'undefined' && 'ALLOW_KEYBOARD_INPUT' in Element;
 


### PR DESCRIPTION
I'd like to this library for my project, which works both on browsers and nodejs. Of course, the fullscreen feature is only meaningful for browsers but some React components, which might include this library, are used for server-side rendering.

This PR just checks `window` and lets `enabled` return falsey and it's enough for react components. Now nodejs can load this library with the `enabled` property:

```
$ node -e 'console.log(require("./src/screenfull").enabled)'
undefined
```