### PR TITLE
Fix for the fix for non-browser environments

### DIFF
--- a/src/screenfull.js
+++ b/src/screenfull.js
@@ -1,7 +1,7 @@
 (function () {
 	'use strict';
 
-	var document = window && typeof window.document !== 'undefined' ? window.document : {};
+	var document = typeof window !== 'undefined' && typeof window.document !== 'undefined' ? window.document : {};
 	var isCommonjs = typeof module !== 'undefined' && module.exports;
 	var keyboardAllowed = typeof Element !== 'undefined' && 'ALLOW_KEYBOARD_INPUT' in Element;
 


### PR DESCRIPTION
Unfortunately the last change broke some server environments (not the ember fastboot one, I tested). This should make it good again.

https://github.com/sindresorhus/screenfull.js/pull/102#issuecomment-308375671