### PR TITLE
Add ability to remove event listeners

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
 				}
 			}
 
-			screenfull.onchange(fullscreenchange);
+			screenfull.on('change', fullscreenchange);
 
 			// Set the initial values
 			fullscreenchange();

--- a/readme.md
+++ b/readme.md
@@ -124,17 +124,23 @@ $('img').on('click', event => {
 
 ```js
 if (screenfull.enabled) {
-	screenfull.onchange(() => {
+	screenfull.on('change', () => {
 		console.log('Am I fullscreen?', screenfull.isFullscreen ? 'Yes' : 'No');
 	});
 }
+```
+
+Remove listeners with:
+
+```js
+screenfull.off('change', callback);
 ```
 
 #### Detect fullscreen error
 
 ```js
 if (screenfull.enabled) {
-	screenfull.onerror(event => {
+	screenfull.on('error', event => {
 		console.error('Failed to enable fullscreen', event);
 	});
 }
@@ -195,13 +201,22 @@ Brings you out of fullscreen.
 
 Requests fullscreen if not active, otherwise exits.
 
+#### .on(event, function)
+
+Add a listener for when the browser switches in and out of fullscreen or when there is an error.
+Events: `change`, `error`.
+
+#### .off(event, function)
+
+Remove a previously registered event listener.
+
 #### .onchange(function)
 
-Add a listener for when the browser switches in and out of fullscreen.
+Alias for `.on('change', function)`
 
 #### .onerror(function)
 
-Add a listener for when the browser cannot switch to fullscreen.
+Alias for `.on('error', function)`
 
 ### Properties
 

--- a/src/screenfull.js
+++ b/src/screenfull.js
@@ -72,6 +72,11 @@
 		return false;
 	})();
 
+	var eventNameMap = {
+		change: fn.fullscreenchange,
+		error: fn.fullscreenerror
+	};
+
 	var screenfull = {
 		request: function (elem) {
 			var request = fn.requestFullscreen;
@@ -99,10 +104,22 @@
 			}
 		},
 		onchange: function (callback) {
-			document.addEventListener(fn.fullscreenchange, callback, false);
+			this.on('change', callback);
 		},
 		onerror: function (callback) {
-			document.addEventListener(fn.fullscreenerror, callback, false);
+			this.on('error', callback);
+		},
+		on: function (event, callback) {
+			var evName = eventNameMap[event];
+			if (evName) {
+				document.addEventListener(evName, callback, false);
+			}
+		},
+		off: function (event, callback) {
+			var evName = eventNameMap[event];
+			if (evName) {
+				document.off(evName, callback, false);
+			}
 		},
 		raw: fn
 	};


### PR DESCRIPTION
The `onchange(function)` and `onerror(function)` api doesn't allow you to easily remove previously registered event listeners. 

To overcome this I added `on(event, function)` and `removeEventListener(event, function)`.