### PR TITLE
Make Safari 5.1 regexp more strict

### DIFF
--- a/src/screenfull.js
+++ b/src/screenfull.js
@@ -87,7 +87,7 @@
 			// keyboard in fullscreen even though it doesn't.
 			// Browser sniffing, since the alternative with
 			// setTimeout is even worse.
-			if (/5\.1[.\d]* Safari/.test(navigator.userAgent)) {
+			if (/ Version\/5\.1(?:\.\d+)? Safari\//.test(navigator.userAgent)) {
 				elem[request]();
 			} else {
 				elem[request](keyboardAllowed && Element.ALLOW_KEYBOARD_INPUT);


### PR DESCRIPTION
This is probably not that big a deal but I felt like the Safari 5.1 detection regexp could be improved to avoid false positives with (in decreasing order of importance):

- potentially upcoming versions: `... Version/15.1 Safari...`
- non-5.1.x versions: `...5.1314132893...`
- cases where Safari isn't the whole word: `...5.1.7 SafariImpersonator...`
- other esoteric cases

I googled up this UA string and successfully tested against it:

`Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2`

Additionally, I wanted to cache the regexp and even the result of the `.test()`, but that's something for a different PR.