### PR TITLE
Remove 'Safari doesn't support keyboard' section in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,8 +68,6 @@ if (document.fullscreenEnabled) {
 
 [Supported browsers](http://caniuse.com/fullscreen)
 
-Safari doesn't support use of the keyboard in fullscreen.
-
 
 ## Documentation
 


### PR DESCRIPTION
Safari does support keyboard use during fullscreen. I can confirm this behavior 100% for Safari 11.1, and if it didn't work before, then all HTML5 video players would fail to have `space` pause the video, which I can also confirm wasn't true on previous versions. Safari **does** however require the use of `event.preventDefault()` for captured keypresses to prevent the 'dong' noise (this is not an issue for textfields).