### PR TITLE
Added check to bypass ALLOW_KEYBOARD_INPUT if it does not exists. As …

### DIFF
--- a/src/screenfull.js
+++ b/src/screenfull.js
@@ -90,7 +90,8 @@
 			if (/ Version\/5\.1(?:\.\d+)? Safari\//.test(navigator.userAgent)) {
 				elem[request]();
 			} else {
-				elem[request](keyboardAllowed && Element.ALLOW_KEYBOARD_INPUT);
+				const allowKeyboardInput = Element.ALLOW_KEYBOARD_INPUT || {};
+				elem[request](keyboardAllowed && allowKeyboardInput);
 			}
 		},
 		exit: function () {


### PR DESCRIPTION
…ALLOW_KEYBOARD_INPUT is undefine din chrome latest version 67.