### PR TITLE
Fix issue with Chrome 67+

### DIFF
--- a/src/screenfull.js
+++ b/src/screenfull.js
@@ -90,7 +90,7 @@
 			if (/ Version\/5\.1(?:\.\d+)? Safari\//.test(navigator.userAgent)) {
 				elem[request]();
 			} else {
-				elem[request](keyboardAllowed && Element.ALLOW_KEYBOARD_INPUT);
+				elem[request](keyboardAllowed ? Element.ALLOW_KEYBOARD_INPUT : {});
 			}
 		},
 		exit: function () {


### PR DESCRIPTION
…D_INPUT anymore. Refactored code to pass empty object if ALLOW_KEYBOARD_INPUT is not found.