### PR TITLE
Verify before exiting fullscreen - Chrome71

### DIFF
--- a/src/screenfull.js
+++ b/src/screenfull.js
@@ -109,9 +109,17 @@
 					resolve();
 				}.bind(this);
 
-				document[fn.exitFullscreen]();
-
-				this.on('change', onFullScreenExit);
+				if (this.isFullscreen) {
+						return document[fn.exitFullscreen]()
+							.then(function () {
+								this.on('change', onFullScreenExit)
+							}.bind(this), function (err) {
+								if (err) {
+									throw new Error(err);
+								}
+							});
+				}
+				return resolve();
 			}.bind(this));
 		},
 		toggle: function (elem) {

--- a/src/screenfull.js
+++ b/src/screenfull.js
@@ -113,13 +113,14 @@
 						return document[fn.exitFullscreen]()
 							.then(function () {
 								this.on('change', onFullScreenExit)
-							}.bind(this), function (err) {
-								if (err) {
-									throw new Error(err);
+							}.bind(this), function (error) {
+								if (error) {
+									throw new Error(error);
 								}
 							});
 				}
-				return resolve();
+
+				resolve();
 			}.bind(this));
 		},
 		toggle: function (elem) {


### PR DESCRIPTION
A problem has appear with the recent version of Chrome 71:

![image](https://user-images.githubusercontent.com/14330374/50848578-ea53b800-1374-11e9-8251-c30d01ce98ad.png)

The problem is discussed [here](https://github.com/jpilfold/ngx-image-viewer/issues/23)

So, I added a verification before exiting.