### PR TITLE
fix for returning the promise returned by element.requestfullscreen

### DIFF
--- a/src/screenfull.js
+++ b/src/screenfull.js
@@ -94,12 +94,14 @@
 				// Browser sniffing, since the alternative with
 				// setTimeout is even worse.
 				if (/ Version\/5\.1(?:\.\d+)? Safari\//.test(navigator.userAgent)) {
-					elem[request]();
+					return (elem[request]()).then(() => {
+						this.on('change', onFullScreenEntered);
+					});
 				} else {
-					elem[request](keyboardAllowed ? Element.ALLOW_KEYBOARD_INPUT : {});
+					(elem[request](keyboardAllowed ? Element.ALLOW_KEYBOARD_INPUT : {})).then(() => {
+						this.on('change', onFullScreenEntered);
+					});
 				}
-
-				this.on('change', onFullScreenEntered);
 			}.bind(this));
 		},
 		exit: function () {

--- a/src/screenfull.js
+++ b/src/screenfull.js
@@ -93,15 +93,20 @@
 				// keyboard in fullscreen even though it doesn't.
 				// Browser sniffing, since the alternative with
 				// setTimeout is even worse.
+				let result;
 				if (/ Version\/5\.1(?:\.\d+)? Safari\//.test(navigator.userAgent)) {
-					return (elem[request]()).then(() => {
-						this.on('change', onFullScreenEntered);
-					});
+					result = elem[request]();
 				} else {
-					(elem[request](keyboardAllowed ? Element.ALLOW_KEYBOARD_INPUT : {})).then(() => {
+					result = elem[request](keyboardAllowed ? Element.ALLOW_KEYBOARD_INPUT : {});
+				}
+				
+				if (!(result instanceof Promise)) {
+					result = Promise.resolve(result);
+				}
+				
+				return result.then(() => {
 						this.on('change', onFullScreenEntered);
 					});
-				}
 			}.bind(this));
 		},
 		exit: function () {


### PR DESCRIPTION
this change returns the promise returned by element.requestfullscreen

this is so the promise can then be chained with a catch in case it fails (for example when a ui action did not start the request) and it won't be left unhandled

Also this ensures that onChange will be properly called once the request full screen promise is resolved (and only if it is resolved)