### PR TITLE
Types inference error in typescript

### DIFF
--- a/src/screenfull.d.ts
+++ b/src/screenfull.d.ts
@@ -166,7 +166,7 @@ declare namespace screenfull {
 /**
 Simple wrapper for cross-browser usage of the JavaScript [Fullscreen API](https://developer.mozilla.org/en/DOM/Using_full-screen_mode), which lets you bring the page or any element into fullscreen. Smoothens out the browser implementation differences, so you don't have to.
 */
-declare const screenfull: screenfull.Screenfull | {isEnabled: false};
+declare const screenfull: screenfull.Screenfull;
 
 export = screenfull;
 export as namespace screenfull;


### PR DESCRIPTION
Typescript compiler can not expect screenfull properties except `isEnabled` when using ` | {isEnabled: false}`.