### PR TITLE
Fix docs typo

### DIFF
--- a/dist/screenfull.d.ts
+++ b/dist/screenfull.d.ts
@@ -47,7 +47,7 @@ declare namespace screenfull {
 
 		Keep in mind that the browser will only enter fullscreen when initiated by user events like click, touch, key.
 
-		@param element - Default is `<html>`. If called with another element than the currently active, it will switch to that if it's a decendant.
+		@param element - Default is `<html>`. If called with another element than the currently active, it will switch to that if it's a descendant.
 		@param options - [`FullscreenOptions`](https://developer.mozilla.org/en-US/docs/Web/API/FullscreenOptions).
 		@returns A promise that resolves after the element enters fullscreen.
 
@@ -102,7 +102,7 @@ declare namespace screenfull {
 		/**
 		Requests fullscreen if not active, otherwise exits.
 
-		@param element - Default is `<html>`. If called with another element than the currently active, it will switch to that if it's a decendant.
+		@param element - Default is `<html>`. If called with another element than the currently active, it will switch to that if it's a descendant.
 		@param options - [`FullscreenOptions`](https://developer.mozilla.org/en-US/docs/Web/API/FullscreenOptions).
 		@returns A promise that resolves after the element enters/exits fullscreen.
 

--- a/readme.md
+++ b/readme.md
@@ -197,7 +197,7 @@ Make an element fullscreen.
 
 Accepts a DOM element and [`FullscreenOptions`](https://developer.mozilla.org/en-US/docs/Web/API/FullscreenOptions).
 
-The default element is `<html>`. If called with another element than the currently active, it will switch to that if it's a decendant.
+The default element is `<html>`. If called with another element than the currently active, it will switch to that if it's a descendant.
 
 If your page is inside an `<iframe>` you will need to add a `allowfullscreen` attribute (+ `webkitallowfullscreen` and `mozallowfullscreen`).
 

--- a/src/screenfull.d.ts
+++ b/src/screenfull.d.ts
@@ -47,7 +47,7 @@ declare namespace screenfull {
 
 		Keep in mind that the browser will only enter fullscreen when initiated by user events like click, touch, key.
 
-		@param element - Default is `<html>`. If called with another element than the currently active, it will switch to that if it's a decendant.
+		@param element - Default is `<html>`. If called with another element than the currently active, it will switch to that if it's a descendant.
 		@param options - [`FullscreenOptions`](https://developer.mozilla.org/en-US/docs/Web/API/FullscreenOptions).
 		@returns A promise that resolves after the element enters fullscreen.
 
@@ -102,7 +102,7 @@ declare namespace screenfull {
 		/**
 		Requests fullscreen if not active, otherwise exits.
 
-		@param element - Default is `<html>`. If called with another element than the currently active, it will switch to that if it's a decendant.
+		@param element - Default is `<html>`. If called with another element than the currently active, it will switch to that if it's a descendant.
 		@param options - [`FullscreenOptions`](https://developer.mozilla.org/en-US/docs/Web/API/FullscreenOptions).
 		@returns A promise that resolves after the element enters/exits fullscreen.
 


### PR DESCRIPTION
There is a small typo in readme.md.

Should read `descendant` rather than `decendant`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md